### PR TITLE
食事ジャンルの追加

### DIFF
--- a/app/controllers/admin/onsens_controller.rb
+++ b/app/controllers/admin/onsens_controller.rb
@@ -25,7 +25,7 @@ class Admin::OnsensController < ApplicationController
 
     respond_to do |format|
       if @onsen.save
-        format.html { redirect_to admin_onsen_path(@onsen), notice: "Onsen was successfully created." }
+        format.html { redirect_to admin_onsen_path(@onsen), notice: "successfully created." }
         format.json { render :show, status: :created, location: @onsen }
       else
         format.html { render :new, status: :unprocessable_entity }
@@ -38,7 +38,7 @@ class Admin::OnsensController < ApplicationController
   def update
     respond_to do |format|
       if @onsen.update(onsen_params)
-        format.html { redirect_to admin_onsen_path(@onsen), notice: "Onsen was successfully updated." }
+        format.html { redirect_to admin_onsen_path(@onsen), notice: "successfully updated." }
         format.json { render :show, status: :ok, location: @onsen }
       else
         format.html { render :edit, status: :unprocessable_entity }
@@ -52,7 +52,7 @@ class Admin::OnsensController < ApplicationController
     @onsen.destroy!
 
     respond_to do |format|
-      format.html { redirect_to admin_onsens_path, status: :see_other, notice: "Onsen was successfully destroyed." }
+      format.html { redirect_to admin_onsens_path, status: :see_other, notice: "successfully destroyed." }
       format.json { head :no_content }
     end
   end

--- a/app/controllers/admin/onsens_controller.rb
+++ b/app/controllers/admin/onsens_controller.rb
@@ -65,6 +65,6 @@ class Admin::OnsensController < ApplicationController
 
     # Only allow a list of trusted parameters through.
     def onsen_params
-      params.expect(onsen: [ :name, :geo_lat, :geo_lng, :description, :tags, images: [] ])
+      params.expect(onsen: [ :name, :geo_lat, :geo_lng, :description, :tags, :pet, images: [] ])
     end
 end

--- a/app/controllers/admin/onsens_controller.rb
+++ b/app/controllers/admin/onsens_controller.rb
@@ -65,6 +65,6 @@ class Admin::OnsensController < ApplicationController
 
     # Only allow a list of trusted parameters through.
     def onsen_params
-      params.expect(onsen: [ :name, :geo_lat, :geo_lng, :description, :tags, :pet, images: [] ])
+      params.expect(onsen: [ :name, :geo_lat, :geo_lng, :description, :tags, :pet, :style, images: [] ])
     end
 end

--- a/app/models/onsen.rb
+++ b/app/models/onsen.rb
@@ -4,7 +4,7 @@ class Onsen < ApplicationRecord
   has_many_attached :images
 
   validates :name, presence: true
-
+  enum :style, { japanese: 0, western: 1 }
   validates :images,
   content_type: [ "image/jpeg", "image/png", "image/gif" ], # 許可ファイル形式
   size: { less_than: 5.megabytes },                       # 1枚あたり5MB未満

--- a/app/views/admin/onsens/_form.html.erb
+++ b/app/views/admin/onsens/_form.html.erb
@@ -32,6 +32,11 @@
     <%= form.text_field :tags, class: "block shadow-sm rounded-md border px-3 py-2 w-full border-gray-300 focus:outline-blue-600" %>
   </div>
   <div>
+    <%= form.label :pet, 'ペット', class: 'block font-semibold mb-1' %>
+    <%= form.check_box :pet %>
+    <%= form.label :pet, "同伴可能" %>
+  </div>
+  <div>
     <%= form.label :images, '画像（最大5枚・JPEG/PNG/GIF）', class: 'block font-semibold mb-1' %>
     <%= form.file_field :images, multiple: true, accept: 'image/jpeg,image/png,image/gif', class: "block border rounded px-2 py-1 w-full" %>
     <% if onsen.images.attached? %>

--- a/app/views/admin/onsens/_form.html.erb
+++ b/app/views/admin/onsens/_form.html.erb
@@ -37,6 +37,13 @@
     <%= form.label :pet, "同伴可能" %>
   </div>
   <div>
+    <%= form.label :style, "ジャンル", class: 'block font-semibold mb-1' %>
+    <%= form.label :style_japanese, "和食" %>
+    <%= form.radio_button :style, "japanese" %>
+    <%= form.label :style_western, "洋食" %>
+    <%= form.radio_button :style, "western" %>
+  </div>
+  <div>
     <%= form.label :images, '画像（最大5枚・JPEG/PNG/GIF）', class: 'block font-semibold mb-1' %>
     <%= form.file_field :images, multiple: true, accept: 'image/jpeg,image/png,image/gif', class: "block border rounded px-2 py-1 w-full" %>
     <% if onsen.images.attached? %>

--- a/app/views/admin/onsens/_onsen.html.erb
+++ b/app/views/admin/onsens/_onsen.html.erb
@@ -11,8 +11,10 @@
   <dd><%= onsen.tags %></dd>
   <dt class="font-semibold">ペット</dt>
   <%if onsen.pet%>
-  <dd>同伴可能</dd>
+    <dd>同伴可能</dd>
   <%else%>
-  <dd>同伴不可</dd>
+    <dd>同伴不可</dd>
   <% end %>
+  <dt class="font-semibold">食事スタイル</dt>
+  <dd><%= onsen.style.present? ? t("enums.style.#{onsen.style}") : "未設定" %></dd>
 </dl>

--- a/app/views/admin/onsens/_onsen.html.erb
+++ b/app/views/admin/onsens/_onsen.html.erb
@@ -9,4 +9,10 @@
   <dd><%= onsen.description %></dd>
   <dt class="font-semibold">タグ</dt>
   <dd><%= onsen.tags %></dd>
+  <dt class="font-semibold">ペット</dt>
+  <%if onsen.pet%>
+  <dd>同伴可能</dd>
+  <%else%>
+  <dd>同伴不可</dd>
+  <% end %>
 </dl>

--- a/app/views/admin/onsens/edit.html.erb
+++ b/app/views/admin/onsens/edit.html.erb
@@ -1,9 +1,9 @@
-<% content_for :title, '温泉情報編集' %>
+<% content_for :title, '店舗情報編集' %>
 <div class="max-w-2xl w-full mx-auto py-8 px-2 sm:px-4">
-  <h1 class="font-bold text-3xl mb-6">温泉情報編集</h1>
+  <h1 class="font-bold text-3xl mb-6">店舗情報編集</h1>
   <%= render "form", onsen: @onsen %>
   <div class="mt-6 flex flex-col sm:flex-row gap-2">
-    <%= link_to 'この温泉を表示', onsen_path(@onsen), target: "_blank", rel: "noopener", class: "rounded-md px-4 py-2 bg-gray-100 hover:bg-gray-200 text-gray-800 font-medium w-full sm:w-auto text-center" %>
+    <%= link_to 'この店舗を表示', onsen_path(@onsen), target: "_blank", rel: "noopener", class: "rounded-md px-4 py-2 bg-gray-100 hover:bg-gray-200 text-gray-800 font-medium w-full sm:w-auto text-center" %>
     <%= link_to '一覧に戻る', admin_onsens_path, class: "rounded-md px-4 py-2 bg-gray-100 hover:bg-gray-200 text-gray-800 font-medium w-full sm:w-auto text-center" %>
   </div>
 </div>

--- a/app/views/admin/onsens/index.html.erb
+++ b/app/views/admin/onsens/index.html.erb
@@ -1,11 +1,11 @@
-<% content_for :title, t('admin.onsens.index.title', default: '温泉一覧') %>
+<% content_for :title, t('admin.onsens.index.title', default: '店舗一覧') %>
 <div class="w-full max-w-5xl mx-auto py-8 px-2 sm:px-4">
   <% if notice.present? %>
     <p class="py-2 px-3 bg-green-50 mb-5 text-green-600 font-medium rounded-md text-center" id="notice"><%= notice %></p>
   <% end %>
   <div class="flex flex-col md:flex-row justify-between items-center mb-6 gap-4">
-    <h1 class="font-bold text-3xl text-gray-800"><%= t('admin.onsens.index.title', default: '温泉一覧') %></h1>
-    <%= link_to t('admin.onsens.index.new', default: '新規温泉登録'), new_admin_onsen_path, class: "rounded-md px-4 py-2 bg-blue-600 hover:bg-blue-500 text-white font-semibold shadow w-full md:w-auto text-center" %>
+    <h1 class="font-bold text-3xl text-gray-800"><%= t('admin.onsens.index.title', default: '店舗一覧') %></h1>
+    <%= link_to t('admin.onsens.index.new', default: '新規店舗登録'), new_admin_onsen_path, class: "rounded-md px-4 py-2 bg-blue-600 hover:bg-blue-500 text-white font-semibold shadow w-full md:w-auto text-center" %>
   </div>
   <div id="admin_onsens" class="divide-y divide-gray-200 w-full overflow-x-auto">
     <% if @onsens.any? %>
@@ -30,7 +30,7 @@
         </div>
       <% end %>
     <% else %>
-      <p class="text-center my-10 text-gray-500">温泉データがありません。</p>
+      <p class="text-center my-10 text-gray-500">店舗データがありません。</p>
     <% end %>
   </div>
 </div>

--- a/app/views/admin/onsens/new.html.erb
+++ b/app/views/admin/onsens/new.html.erb
@@ -1,6 +1,6 @@
-<% content_for :title, '温泉新規登録' %>
+<% content_for :title, '店舗新規登録' %>
 <div class="max-w-2xl w-full mx-auto py-8 px-2 sm:px-4">
-  <h1 class="font-bold text-3xl mb-6">温泉新規登録</h1>
+  <h1 class="font-bold text-3xl mb-6">店舗新規登録</h1>
   <%= render "form", onsen: @onsen %>
   <div class="mt-6 flex flex-col sm:flex-row gap-2">
     <%= link_to '一覧に戻る', admin_onsens_path, class: "rounded-md px-4 py-2 bg-gray-100 hover:bg-gray-200 text-gray-800 font-medium w-full sm:w-auto text-center" %>

--- a/app/views/admin/onsens/show.html.erb
+++ b/app/views/admin/onsens/show.html.erb
@@ -1,9 +1,9 @@
-<% content_for :title, '温泉詳細' %>
+<% content_for :title, '店舗詳細' %>
 <div class="max-w-2xl w-full mx-auto py-8">
   <% if notice.present? %>
     <p class="py-2 px-3 bg-green-50 mb-5 text-green-600 font-medium rounded-md text-center" id="notice"><%= notice %></p>
   <% end %>
-  <h1 class="font-bold text-3xl mb-6">温泉詳細</h1>
+  <h1 class="font-bold text-3xl mb-6">店舗詳細</h1>
   <%= render partial: 'onsen', locals: { onsen: @onsen } %>
   <% if @onsen.images.attached? %>
     <div class="flex flex-wrap gap-2 mt-4">

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -4,6 +4,6 @@
       <a href="#" class="hover:underline" aria-label="利用規約">利用規約</a>
       <a href="#" class="hover:underline" aria-label="お問い合わせ">お問い合わせ</a>
     </div>
-    <div class="text-gray-400">© <%= Time.current.year %> 松江温泉マップ. All rights reserved.</div>
+    <div class="text-gray-400">© <%= Time.current.year %> 松江お菓子マップ. All rights reserved.</div>
   </div>
 </footer>

--- a/app/views/onsens/_search_form.html.erb
+++ b/app/views/onsens/_search_form.html.erb
@@ -12,9 +12,9 @@
                      class: "block text-sm font-bold mb-1" %>
         <%= f.text_field :q, value: params[:q],
                           class: "w-full border rounded px-3 py-2",
-                          placeholder: "例：玉造温泉",
+                          placeholder: "例：松江洋菓子店",
                           'aria-label': t('views.onsens.index.search') %>
-        <p class="text-xs text-gray-600 mt-1">温泉名や説明文で検索できます</p>
+        <p class="text-xs text-gray-600 mt-1">店舗名や説明文で検索できます</p>
       </div>
       <%# タグでの絞り込み検索 %>
       <div>
@@ -22,7 +22,7 @@
                      class: "block text-sm font-bold mb-1" %>
         <%= f.text_field :tags, value: params[:tags],
                           class: "w-full border rounded px-3 py-2",
-                          placeholder: "例：露天風呂,美肌",
+                          placeholder: "例：スイーツ",
                           'aria-label': t('activerecord.attributes.onsen.tags') %>
         <p class="text-xs text-gray-600 mt-1">カンマ区切りで複数指定可能</p>
       </div>

--- a/app/views/onsens/_search_form.html.erb
+++ b/app/views/onsens/_search_form.html.erb
@@ -1,9 +1,9 @@
-<%# 温泉検索フォーム用パーシャル %>
+<%# 店舗検索フォーム用パーシャル %>
 <%# 複合検索機能を提供：テキスト検索 + タグ検索 + 位置情報検索 %>
-<div class="mb-6" role="search" aria-label="温泉検索">
+<div class="mb-6" role="search" aria-label="店舗検索">
   <%= form_with url: onsens_path, method: :get, local: true,
                 class: "space-y-4 p-4 border rounded-lg bg-gray-50",
-                'aria-label': "温泉検索フォーム" do |f| %>
+                'aria-label': "店舗検索フォーム" do |f| %>
     <%# テキスト・タグ検索セクション %>
     <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
       <%# 温泉名・説明文での検索 %>

--- a/app/views/onsens/_spot_card.html.erb
+++ b/app/views/onsens/_spot_card.html.erb
@@ -22,6 +22,13 @@
           <span class="text-xs text-gray-400">未評価</span>
         <% end %>
       </div>
+        <div class="text-xs text-gray-500 mb-2">
+      <% if onsen.pet.present? %>
+          <span class="font-medium">ペット✅</span> 
+        <% else %>
+          <span class="font-medium">ペット☒</span> 
+      <% end %>
+        </div>
     </div>
   </div>
 <% end %>

--- a/app/views/onsens/_spot_card.html.erb
+++ b/app/views/onsens/_spot_card.html.erb
@@ -22,13 +22,19 @@
           <span class="text-xs text-gray-400">未評価</span>
         <% end %>
       </div>
-        <div class="text-xs text-gray-500 mb-2">
-      <% if onsen.pet.present? %>
-          <span class="font-medium">ペット✅</span> 
+      <div class="text-xs text-gray-500 mb-2">
+        <% if onsen.pet.present? %>
+          <span class="font-medium">ペット✅</span>
         <% else %>
-          <span class="font-medium">ペット☒</span> 
-      <% end %>
-        </div>
+          <span class="font-medium">ペット☒</span>
+        <% end %>
+        <% if onsen.style.present? %>
+          <div class="text-xs text-gray-500 mb-2">
+            <span class="font-medium">食事スタイル:</span>
+            <%= t("enums.style.#{onsen.style}") %>
+          </div>
+        <% end %>
+      </div>
     </div>
   </div>
 <% end %>

--- a/app/views/onsens/index.html.erb
+++ b/app/views/onsens/index.html.erb
@@ -23,14 +23,14 @@
       <div class="space-y-4 lg:max-h-[600px] lg:overflow-y-auto lg:pr-2">
         <% if @onsens.any? %>
           <p class="text-sm text-gray-600 mb-4">
-            検索結果: <%= @onsens.count %>件の温泉が見つかりました
+            検索結果: <%= @onsens.count %>件の店舗が見つかりました
           </p>
           <% @onsens.each do |onsen| %>
             <%= render partial: "spot_card", locals: { onsen: onsen } %>
           <% end %>
         <% else %>
           <div class="text-center py-8 text-gray-500">
-            <p class="text-lg mb-2">🔍 温泉が見つかりませんでした</p>
+            <p class="text-lg mb-2">🔍 店舗が見つかりませんでした</p>
             <p class="text-sm">検索条件を変更してお試しください</p>
           </div>
         <% end %>

--- a/app/views/reviews/new.html.erb
+++ b/app/views/reviews/new.html.erb
@@ -1,12 +1,10 @@
 <% content_for :title, "#{@onsen.name}にレビューを投稿" %>
-
 <div class="container mx-auto px-4 py-6">
   <% if notice.present? %>
     <div class="bg-green-50 border border-green-200 text-green-700 px-4 py-3 rounded mb-6">
       <%= notice %>
     </div>
   <% end %>
-
   <div class="max-w-2xl mx-auto">
     <%# ヘッダー部分 %>
     <div class="mb-6">
@@ -18,18 +16,15 @@
         <% end %>
         <h1 class="text-2xl font-bold text-gray-900">レビューを投稿</h1>
       </div>
-      
       <div class="bg-blue-50 border border-blue-200 rounded-lg p-4">
         <h2 class="text-lg font-semibold text-blue-900 mb-2"><%= @onsen.name %></h2>
-        <p class="text-blue-700 text-sm">この温泉の感想をお聞かせください</p>
+        <p class="text-blue-700 text-sm">この店舗の感想をお聞かせください</p>
       </div>
     </div>
-
     <%# レビューフォーム %>
     <div class="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
       <%= render "form", onsen: @onsen, review: @review %>
     </div>
-
     <%# 注意事項 %>
     <div class="mt-6 bg-gray-50 rounded-lg p-4">
       <h3 class="text-sm font-medium text-gray-900 mb-2">レビュー投稿について</h3>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,11 +1,11 @@
 ja:
   activerecord:
     models:
-      onsen: 温泉
+      onsen: 店舗
       review: レビュー
     attributes:
       onsen:
-        name: 温泉名
+        name: 店舗名
         geo_lat: 緯度
         geo_lng: 経度
         description: 説明
@@ -76,15 +76,15 @@ ja:
       update: "%{model}を更新する"
   views:
     navigation:
-      site_title: 松江温泉マップ
+      site_title: 松江お菓子マップ
       search: 検索
       admin: 管理画面
-      onsen_management: 温泉管理
+      onsen_management: 店舗管理
       public_site: 公開サイト
     onsens:
     onsens:
       index:
-        title: 松江市周辺の温泉一覧
+        title: 松江市周辺の店舗一覧
         search: 検索
         radius_km: 半径(km)
         address: 住所
@@ -102,11 +102,11 @@ ja:
   admin:
     onsens:
       create:
-        success: "温泉を登録しました"
+        success: "店舗を登録しました"
       update:
-        success: "温泉情報を更新しました"
+        success: "店舗情報を更新しました"
       destroy:
-        success: "温泉を削除しました"
+        success: "店舗を削除しました"
       import:
         success: "インポート完了"
         skipped: "インポート完了（%{count}行スキップ）"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -15,6 +15,10 @@ ja:
         rating: 評価
         comment: コメント
         images: 画像
+  enums:
+    style:
+      japanese: "和食"
+      western: "洋食"
   errors:
     format: "%{attribute} %{message}"
     messages:

--- a/db/migrate/20250826061602_add_pet_to_onsens.rb
+++ b/db/migrate/20250826061602_add_pet_to_onsens.rb
@@ -1,0 +1,5 @@
+class AddPetToOnsens < ActiveRecord::Migration[8.0]
+  def change
+    add_column :onsens, :pet, :boolean
+  end
+end

--- a/db/migrate/20250826122458_add_style_to_onsens.rb
+++ b/db/migrate/20250826122458_add_style_to_onsens.rb
@@ -1,0 +1,5 @@
+class AddStyleToOnsens < ActiveRecord::Migration[8.0]
+  def change
+    add_column :onsens, :style, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_07_23_085142) do
+ActiveRecord::Schema[8.0].define(version: 2025_08_26_061602) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -50,6 +50,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_07_23_085142) do
     t.string "tags"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "pet"
   end
 
   create_table "reviews", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_08_26_061602) do
+ActiveRecord::Schema[8.0].define(version: 2025_08_26_122458) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -51,6 +51,9 @@ ActiveRecord::Schema[8.0].define(version: 2025_08_26_061602) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.boolean "pet"
+    t.integer "foodstale"
+    t.integer "foodstyle"
+    t.integer "style"
   end
 
   create_table "reviews", force: :cascade do |t|


### PR DESCRIPTION
enum型で食事ジャンルを保存するstyleを追加（DBはinteger型）japanese:0, western:1
ja.ymlにjapanese:和食 western:洋食　と設定
管理画面の情報追加・変更にジャンルを選ぶラジオボタンを追加
ジャンルを表示するように管理画面・公開画面を変更（管理画面：未設定なら未設定と表示　公開画面：未設定なら表示なし）


